### PR TITLE
Add decoded dataframe reconstruction utility

### DIFF
--- a/generate_data_vae.py
+++ b/generate_data_vae.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import torch
+import pandas as pd
+import numpy as np
+
+from src.data.clean import clean
+from src.data.wrangle import wrangle
+from src.data import split_numerical_categorical, reconstruct_decoded_dataframe
+from src.trainer.vae_trainer import VAETrainer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate synthetic data using a trained VAE")
+    parser.add_argument('--data_path', type=str, default='FACE/neuropsy_v0.csv',
+                        help='Path to the raw CSV used during training')
+    parser.add_argument('--checkpoint', type=str, default='ckpt/model.pt',
+                        help='Path to the trained VAE checkpoint')
+    parser.add_argument('--num_samples', type=int, default=1000,
+                        help='Number of synthetic rows to generate')
+    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu',
+                        help='Device to use (cpu, cuda, mps)')
+    parser.add_argument('--n_cols', type=int, default=60,
+                        help='Number of wrangled columns used during training')
+    parser.add_argument('--output', type=str, default='generated_samples/generated_data.csv',
+                        help='Where to save the generated data CSV')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # ─── load and preprocess dataset identically to training ────────────────
+    df_raw = pd.read_csv(args.data_path, sep=';', low_memory=False)
+    # drop duplicated ID/visit columns if present
+    cols_to_drop = [
+        'usubjid_neuropsychologie',
+        'visitnum_neuropsychologie',
+        'visit_neuropsychologie',
+        'visit_neuropsychologie',  # kept as in original script
+    ]
+    df_raw = df_raw.drop(columns=[c for c in cols_to_drop if c in df_raw.columns], errors='ignore')
+
+    df_clean = clean(df_raw)
+    df_wrangled, _params, wrangler = wrangle(
+        df_clean,
+        conversion_threshold=0.80,
+        cardinality_threshold=10,
+        scale_numeric=True,
+    )
+
+    df_partial = df_wrangled[df_wrangled.columns[: args.n_cols]]
+
+    num_mat, cat_mat, mapping = split_numerical_categorical(df_partial, cardinality_threshold=10)
+    num_mat = num_mat.astype(np.float32)
+    cat_mat = cat_mat.astype(np.int64)
+
+    # ─── load model ──────────────────────────────────────────────────────────
+    model, _model_cfg = VAETrainer.load_model(args.checkpoint, device=args.device)
+
+    # ─── generate synthetic samples ─────────────────────────────────────────
+    with torch.no_grad():
+        x_num, x_cat = model.sample(args.num_samples, current_device=args.device)
+
+    # ─── reconstruct dataframe in original format ──────────────────────────
+    df_generated = reconstruct_decoded_dataframe(
+        numerical_matrix=x_num,
+        categorical_matrix=x_cat,
+        mapping=mapping,
+        wrangler=wrangler,
+        drop_scaled=True,
+    )
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    df_generated.to_csv(args.output, index=False)
+    print(f"Saved {len(df_generated)} rows to {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,7 +1,8 @@
 from src.data.dataset import (
     TabularDataset,
     split_numerical_categorical,
-    preprocess_data
+    preprocess_data,
+    reconstruct_decoded_dataframe,
 )
 from src.data.data_module import VAEDataModule
 
@@ -9,5 +10,6 @@ __all__ = [
     'TabularDataset',
     'split_numerical_categorical',
     'preprocess_data',
-    'VAEDataModule'
+    'VAEDataModule',
+    'reconstruct_decoded_dataframe'
 ]

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -15,6 +15,7 @@ from sklearn.preprocessing import (
 )
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
+from src.data.wrangle import DataWrangler
 
 
 ScalerStrategy = Literal["standard", "minmax", "quantile", None]
@@ -334,3 +335,70 @@ def update_ema(target_params, source_params, rate=0.999):
     """
     for target, source in zip(target_params, source_params):
         target.detach().mul_(rate).add_(source.detach(), alpha=1 - rate)
+
+
+def reconstruct_decoded_dataframe(
+    numerical_matrix: Union[np.ndarray, torch.Tensor],
+    categorical_matrix: Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]],
+    mapping: Dict[str, Any],
+    wrangler: "DataWrangler",
+    *,
+    drop_scaled: bool = True,
+) -> pd.DataFrame:
+    """Rebuild and decode a DataFrame from generated VAE outputs.
+
+    Parameters
+    ----------
+    numerical_matrix:
+        Generated numerical values (``n_samples``\ x ``n_num_features``).
+    categorical_matrix:
+        Generated categorical data either as one NumPy array of class indices
+        or a list/array of class probability tensors.
+    mapping:
+        Mapping dictionary returned by :func:`split_numerical_categorical` from
+        the original training data.
+    wrangler:
+        Fitted :class:`~src.data.wrangle.DataWrangler` used during preprocessing
+        (provides inverse transformations).
+    drop_scaled:
+        Passed to :meth:`DataWrangler.inverse_transform` indicating whether
+        numeric features should be restored to their original scale.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with original column order and decoded values.
+    """
+
+    # ─── convert tensors and probabilities to integer matrices ──────────────
+    if isinstance(numerical_matrix, torch.Tensor):
+        numerical_matrix = numerical_matrix.cpu().numpy()
+
+    if isinstance(categorical_matrix, list):
+        cat_arrs = []
+        for cat in categorical_matrix:
+            if isinstance(cat, torch.Tensor):
+                cat = cat.cpu().numpy()
+            if cat.ndim > 1:
+                cat = cat.argmax(axis=1)
+            cat_arrs.append(cat)
+        categorical_matrix = np.column_stack(cat_arrs) if cat_arrs else np.empty((len(numerical_matrix), 0))
+    else:
+        if isinstance(categorical_matrix, torch.Tensor):
+            categorical_matrix = categorical_matrix.cpu().numpy()
+        if categorical_matrix.ndim > 1 and categorical_matrix.shape[-1] > 1:
+            categorical_matrix = categorical_matrix.argmax(axis=-1)
+
+    # ─── adjust mapping index for new rows ───────────────────────────────────
+    mapping = mapping.copy()
+    mapping["index"] = pd.RangeIndex(start=0, stop=numerical_matrix.shape[0])
+
+    df_encoded = reconstruct_dataframe(
+        numerical_matrix=numerical_matrix,
+        categorical_matrix=categorical_matrix,
+        mapping=mapping,
+    )
+
+    # Use wrangler to decode categorical values and undo scaling
+    decoded_df = wrangler.inverse_transform(df_encoded, drop_scaled=drop_scaled)
+    return decoded_df


### PR DESCRIPTION
## Summary
- add helper `reconstruct_decoded_dataframe` to rebuild a DataFrame from VAE generated arrays and decode values via `DataWrangler`
- expose the helper in `src.data` package
- add script `generate_data_vae.py` to load pipeline components and generate decoded synthetic data

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_683eb981851c8328b3f2764b3aa40da2